### PR TITLE
Feature/cpu tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include_directories(
   ${X11_INCLUDE_DIR}
 )
 
-add_definitions(-std=gnu++11 -o3 -fext-numeric-literals)
+add_definitions(-std=gnu++11 -Ofast -march=native -fext-numeric-literals)
 
 add_library(${PROJECT_NAME}
   src/x11_window.cpp
@@ -60,7 +60,7 @@ add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 add_executable(state_monitor_node
   src/state_monitor_node.cpp
 )
-target_link_libraries(state_monitor_node ${PROJECT_NAME} ${catkin_LIBRARIES} ${X11_LIBRARIES} -lmgl-fltk)
+target_link_libraries(state_monitor_node ${PROJECT_NAME} ${catkin_LIBRARIES} ${X11_LIBRARIES} -lmgl)
 
 # Install header files
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple GUI for monitoring the state of a range of ASL estimators
 
 # Dependencies
 
-State Monitor depends on mathgl and X11. These can be installed via `sudo apt install libmgl-dev libx11-dev`
+State Monitor depends on mathgl and X11. To stop runaway cpu usage it also needs numactl. These can be installed via `sudo apt install libmgl-dev libx11-dev numactl`
 
 # Usage
 

--- a/include/state_monitor/x11_window.h
+++ b/include/state_monitor/x11_window.h
@@ -10,7 +10,7 @@
 
 class X11Window {
  public:
-  X11Window(const size_t graph_quality = 0);
+  X11Window(const size_t graph_quality = 4);
 
   void render();
 

--- a/src/state_monitor.cpp
+++ b/src/state_monitor.cpp
@@ -4,7 +4,7 @@ StateMonitor::StateMonitor(const ros::NodeHandle& nh,
                            const ros::NodeHandle& nh_private) {
   nh_private_.param("plot_time_length_secs", plot_time_length_secs_, 10.0);
   double plot_update_rate_hz;
-  nh_private_.param("plot_update_rate_hz", plot_update_rate_hz, 20.0);
+  nh_private_.param("plot_update_rate_hz", plot_update_rate_hz, 5.0);
 
   draw_timer_ = nh_.createTimer(ros::Duration(1.0 / plot_update_rate_hz),
                                 &StateMonitor::drawCallback, this);

--- a/src/state_monitor.cpp
+++ b/src/state_monitor.cpp
@@ -4,7 +4,7 @@ StateMonitor::StateMonitor(const ros::NodeHandle& nh,
                            const ros::NodeHandle& nh_private) {
   nh_private_.param("plot_time_length_secs", plot_time_length_secs_, 10.0);
   double plot_update_rate_hz;
-  nh_private_.param("plot_update_rate_hz", plot_update_rate_hz, 5.0);
+  nh_private_.param("plot_update_rate_hz", plot_update_rate_hz, 10.0);
 
   draw_timer_ = nh_.createTimer(ros::Duration(1.0 / plot_update_rate_hz),
                                 &StateMonitor::drawCallback, this);

--- a/src/x11_window.cpp
+++ b/src/x11_window.cpp
@@ -1,6 +1,7 @@
 #include "state_monitor/x11_window.h"
 
 X11Window::X11Window(const size_t graph_quality) {
+
   gr_ = std::make_shared<mglGraph>();
   // a value of 0 enforces a black background but halves cpu usage
   gr_->SetQuality(graph_quality);

--- a/src/x11_window.cpp
+++ b/src/x11_window.cpp
@@ -1,7 +1,7 @@
 #include "state_monitor/x11_window.h"
 
 X11Window::X11Window(const size_t graph_quality) {
-  gr_ = std::make_shared<mglFLTK>();
+  gr_ = std::make_shared<mglGraph>();
   // a value of 0 enforces a black background but halves cpu usage
   gr_->SetQuality(graph_quality);
   gr_->Alpha(false);

--- a/state_monitor
+++ b/state_monitor
@@ -4,7 +4,7 @@ ROS_RUNNING=$(rostopic list | head -c1)
 
 if [ "$ROS_RUNNING" == "/" ]
 then
-  rosrun state_monitor state_monitor_node
+  numactl --physcpubind=+0 rosrun state_monitor state_monitor_node
 else
   echo "No roscore found, could not start state monitor."
 fi


### PR DESCRIPTION
a range of tweaks to get the cpu usage down, weirdly the one that makes the biggest difference is numactl as while the system tries to use all cores it must do a crap job of it, and actually runs far better limited to one core. mathgl has a flag for running on 1 core, but it doesn't seem to work, hence the workaround.

I also looked into the mathgl OpenGL interface but even the hello world examples were having issues.

On my pc takes cpu usage from 350% -> 50%